### PR TITLE
Fix UB in `hotline_plugin!`

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -139,13 +139,12 @@ macro_rules! hotline_plugin {
     ($input:ident) => {
         /// Plugins are created on the heap and the instance is passed from the client to the plugin function calls
         fn new_plugin<T : Plugin<crate::gfx_platform::Device, crate::os_platform::App> + Sized>() -> *mut T {
-            unsafe {
-                let layout = std::alloc::Layout::from_size_align(
-                    std::mem::size_of::<T>(),
-                    8,
-                )
-                .unwrap();
-                std::alloc::alloc_zeroed(layout) as *mut T
+            if std::mem::size_of::<T>() == 0 {
+                std::ptr::NonNull::dangling().as_ptr()
+            } else {
+                unsafe {
+                    std::alloc::alloc_zeroed(std::alloc::Layout::new::<T>()) as *mut T
+                }
             }
         }
         

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -153,7 +153,7 @@ macro_rules! hotline_plugin {
         pub fn create() -> *mut core::ffi::c_void {
             let ptr = new_plugin::<$input>() as *mut core::ffi::c_void;
             unsafe {
-                let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
+                let plugin = ptr.cast::<$input>();
                 plugin.write($input::create());
             }
             ptr
@@ -163,7 +163,7 @@ macro_rules! hotline_plugin {
         #[no_mangle]
         pub fn update(mut client: client::Client<gfx_platform::Device, os_platform::App>, ptr: *mut core::ffi::c_void) -> client::Client<gfx_platform::Device, os_platform::App> {
             unsafe { 
-                let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
+                let plugin = ptr.cast::<$input>();
                 let plugin = plugin.as_mut().unwrap();
                 plugin.update(client)
             }
@@ -173,7 +173,7 @@ macro_rules! hotline_plugin {
         #[no_mangle]
         pub fn setup(mut client: client::Client<gfx_platform::Device, os_platform::App>, ptr: *mut core::ffi::c_void) -> client::Client<gfx_platform::Device, os_platform::App> {
             unsafe { 
-                let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
+                let plugin = ptr.cast::<$input>();
                 let plugin = plugin.as_mut().unwrap();
                 plugin.setup(client)
             }
@@ -183,7 +183,7 @@ macro_rules! hotline_plugin {
         #[no_mangle]
         pub fn unload(mut client: client::Client<gfx_platform::Device, os_platform::App>, ptr: *mut core::ffi::c_void) -> client::Client<gfx_platform::Device, os_platform::App> {
             unsafe { 
-                let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
+                let plugin = ptr.cast::<$input>();
                 let plugin = plugin.as_mut().unwrap();
                 plugin.unload(client)
             }
@@ -193,7 +193,7 @@ macro_rules! hotline_plugin {
         #[no_mangle]
         pub fn ui(mut client: client::Client<gfx_platform::Device, os_platform::App>, ptr: *mut core::ffi::c_void, imgui_ctx: *mut core::ffi::c_void) -> client::Client<gfx_platform::Device, os_platform::App> {
             unsafe { 
-                let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
+                let plugin = ptr.cast::<$input>();
                 let plugin = plugin.as_mut().unwrap();
                 client.imgui.set_current_context(imgui_ctx);
                 plugin.ui(client)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -155,8 +155,7 @@ macro_rules! hotline_plugin {
             let ptr = new_plugin::<$input>() as *mut core::ffi::c_void;
             unsafe {
                 let plugin = std::mem::transmute::<*mut core::ffi::c_void, *mut $input>(ptr);
-                let plugin = plugin.as_mut().unwrap();
-                *plugin = $input::create();
+                plugin.write($input::create());
             }
             ptr
         }


### PR DESCRIPTION
Hi! I saw your project in https://www.polymonster.co.uk/blog/building-new-engine-3, this is some cool stuff, congrats! I then looked at the code and I noticed there was some UB in the `hotline_plugin!` macro that was trivial to fix, so here I am.

The commits should be self-explanatory, but anyway what they fix is:

- in `create` you were assigning with `*plugin = ...`, but this drops the "old" plugin that was contained in `plugin`. The problem is that `plugin` is zero initialized, so there's no plugin to drop and this is UB. Imagine for example if the plugin was something like `struct Plugin(Box<i32>);`, it would try to deallocate a null pointer. I replaced this with `<*mut T>::write`, which does not drop the "old" plugin.

- in `new_plugin` you were calling `alloc_zeroed` with a layout that has the size of `T` and an alignment of 8. This is problematic for two reasons:
  - `alloc_zeroed` wants a non-zero size layout (see the documentation of [`GlobalAlloc::alloc`](https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html#tymethod.alloc), which it delegates to), but you never check if `T` has a size of 0.
  - an alignment of 8 might not be enough (it will probably be in most cases, but it's still UB if someone creates a `#[repr(align(32))] type or something like that)
 
   I fixed this by using a dangling pointer for zero sized types (this is what the stdlib does as well) and using `Layout::new::<T>()` otherwise (which does use the correct alignment, and also avoids an `unwrap`). The deallocation code might need some adjustment too, but I couldn't find it. Note that I later replaced this with a `Box`, but you might case about this if you wanted to drop the later commits, which might be a bit more questionable.

- (questionable) I replaced the `transmute`s with pointer casts, which should be semantically more correct (but probably this doesn't matter)

- (questionable) I replaced the `new_plugin` + `write` call with just a `Box::into_raw(Box::new($input::create()))`, which I feel is just simplier, doesn't require `unsafe` and does the same thing.

There might be other things to improve which I didn't address in this PR. For example if any of the plugin method panics then that's UB because the panic is not catched before the FFI boundary. 
Another improvement might be reffering explicitly to the plugin methods with `<$input as $crate::plugin::Plugin>::create()` ecc ecc so that there's no way they might be mistaken for inherent methods.