### PR TITLE
Raytracing support with DXR backend

### DIFF
--- a/config.jsn
+++ b/config.jsn
@@ -113,11 +113,12 @@
         pmfx: {
             args: [
                 "-shader_platform hlsl"
-                "-shader_version 6_0"
+                "-shader_version 6_3"
                 "-i ${src_shader_dir}/"
                 "-o ${data_dir}/shaders"
                 "-t ${temp_dir}/shaders"
                 "-num_threads 1"
+                "-f"
                 "-args"
                 "-Zpr"
             ]

--- a/config.jsn
+++ b/config.jsn
@@ -126,7 +126,7 @@
             explicit: true
             args: [
                 "-shader_platform hlsl"
-                "-shader_version 6_0"
+                "-shader_version 6_3"
                 "-i ${src_shader_dir}/"
                 "-o ${data_dir}/shaders"
                 "-t ${temp_dir}/shaders"
@@ -147,6 +147,7 @@
                 "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyRaygenShader -Fo ${output_dir}/raygen.cso -I . shaders/raytracing_example.hlsl"
                 "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyClosestHitShader -Fo ${output_dir}/closesthit.cso -I . shaders/raytracing_example.hlsl"
                 "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyMissShader -Fo ${output_dir}/miss.cso -I . shaders/raytracing_example.hlsl"
+                "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -Fo ${output_dir}/lib.cso -I . shaders/raytracing_example.hlsl"
             ]
         }
     }

--- a/config.jsn
+++ b/config.jsn
@@ -3,7 +3,7 @@
     tools<windows>: {
         pmfx: "hotline-data/bin/win32/pmfx/pmfx.exe"
         texturec: "hotline-data/bin/win32/texturec/texturec.exe"
-        pmfx_dev: "../pmfx-shader/pmfx.py"
+        pmfx_dev: "py -3 ../pmfx-shader/pmfx.py"
     }
 
     tools_help: {

--- a/config.jsn
+++ b/config.jsn
@@ -138,6 +138,20 @@
         }
     }
 
+    rt_shaders: {
+        jsn_vars: {
+            output_dir: "target/data/shaders"
+        }
+        shell: {
+            commands: [
+                "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyRaygenShader -Fo ${output_dir}/raygen.cso -I . shaders/raytracing_example.hlsl"
+                "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyClosestHitShader -Fo ${output_dir}/closesthit.cso -I . shaders/raytracing_example.hlsl"
+                "hotline-data\\bin\\win32\\pmfx\\bin\\dxc\\dxc.exe -T lib_6_3 -E MyMissShader -Fo ${output_dir}/miss.cso -I . shaders/raytracing_example.hlsl"
+            ]
+        }
+    }
+
+
     // win32 debug client, plugins and data
     win32-debug(win32-data, hotline): {
         copy: {

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -38,7 +38,6 @@ fn main() -> Result<(), hotline_rs::Error> {
         ..Default::default()
     });
 
-    
     let swap_chain_info = gfx::SwapChainInfo {
         num_buffers,
         format: gfx::Format::RGBA8n,
@@ -99,7 +98,7 @@ fn main() -> Result<(), hotline_rs::Error> {
         build_flags: AccelerationStructureBuildFlags::PREFER_FAST_TRACE
     })?;
 
-    let _ = device.create_raytracing_tlas(&RaytracingTLASInfo {
+    let tlas = device.create_raytracing_tlas(&RaytracingTLASInfo {
         instances: &vec![RaytracingInstanceInfo {
             transform: [0.0; 12],
             instance_id: 0,
@@ -111,7 +110,20 @@ fn main() -> Result<(), hotline_rs::Error> {
         build_flags: AccelerationStructureBuildFlags::PREFER_FAST_TRACE
     })?;
 
-    // TODO: dispatch rays
+    // unordered access rw texture
+    let rw_info = gfx::TextureInfo {
+        format: gfx::Format::RGBA8n,
+        tex_type: gfx::TextureType::Texture2D,
+        width: 512,
+        height: 512,
+        depth: 1,
+        array_layers: 1,
+        mip_levels: 1,
+        samples: 1,
+        usage: gfx::TextureUsage::SHADER_RESOURCE | gfx::TextureUsage::UNORDERED_ACCESS,
+        initial_state: gfx::ResourceState::ShaderResource,
+    };
+    let _rw_tex = device.create_texture::<u8>(&rw_info, None).unwrap();
 
     while app.run() {
         // update window and swap chain
@@ -126,6 +138,10 @@ fn main() -> Result<(), hotline_rs::Error> {
         // build command buffer and make draw calls
         cmd.reset(&swap_chain);
 
+        // TODO:
+        // bind rw
+        // dispatch rays
+
         cmd.transition_barrier(&gfx::TransitionBarrier {
             texture: Some(swap_chain.get_backbuffer_texture()),
             buffer: None,
@@ -136,6 +152,9 @@ fn main() -> Result<(), hotline_rs::Error> {
         cmd.begin_render_pass(swap_chain.get_backbuffer_pass_mut());
         cmd.set_viewport(&viewport);
         cmd.set_scissor_rect(&scissor);
+
+        // TODO:
+        // blit output to backbuffer
         
         cmd.end_render_pass();
 

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -56,36 +56,10 @@ fn main() -> Result<(), hotline_rs::Error> {
     let mut swap_chain = device.create_swap_chain::<os_platform::App>(&swap_chain_info, &window)?;
     let mut cmd = device.create_cmd_buf(num_buffers);
 
-
     let mut pmfx : pmfx::Pmfx<gfx_platform::Device> = pmfx::Pmfx::create(&mut device, 0);
     pmfx.load(&hotline_rs::get_data_path("shaders/raytracing_example"))?;
     pmfx.create_raytracing_pipeline(&device, "raytracing");
 
-    /*
-    // create raytracing shaders
-    let raygen_shader = device.create_shader(&gfx::ShaderInfo {
-        shader_type: gfx::ShaderType::RayGen,
-        compile_info: None
-    }, &fs::read(hotline_rs::get_data_path("shaders/raygen.cso"))?)?;
-
-    let closest_hit_shader = device.create_shader(&gfx::ShaderInfo {
-        shader_type: gfx::ShaderType::ClosestHit,
-        compile_info: None
-    }, &fs::read(hotline_rs::get_data_path("shaders/closesthit.cso"))?)?;
-
-    let miss_shader = device.create_shader(&gfx::ShaderInfo {
-        shader_type: gfx::ShaderType::Miss,
-        compile_info: None
-    }, &fs::read(hotline_rs::get_data_path("shaders/miss.cso"))?)?;
-
-    // create raytracing pipeline
-    let raytracing_pipeline = device.create_raytracing_pipeline(&RaytracingPipelineInfo{
-        raygen_shader: Some((&raygen_shader, "MyRaygenShader")),
-        closest_hit_shader: None, //Some((&closest_hit_shader, "MyClosestHitShader")),
-        miss_shader: None, // Some((&miss_shader, "MyMissShader")),
-    });
-    */
-    
     while app.run() {
         // update window and swap chain
         window.update(&mut app);

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -1,4 +1,3 @@
-use gfx::RaytracingPipelineInfo;
 use hotline_rs::*;
 
 use gfx::CmdBuf;
@@ -8,17 +7,9 @@ use gfx::SwapChain;
 use os::App;
 use os::Window;
 
-use std::fs;
-
 #[cfg(target_os = "windows")]
 use os::win32 as os_platform;
 use gfx::d3d12 as gfx_platform;
-
-#[repr(C)]
-struct Vertex {
-    position: [f32; 3],
-    color: [f32; 4],
-}
 
 fn main() -> Result<(), hotline_rs::Error> {
     let mut app = os_platform::App::create(os::AppInfo {

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -58,42 +58,8 @@ fn main() -> Result<(), hotline_rs::Error> {
 
     let mut pmfx : pmfx::Pmfx<gfx_platform::Device> = pmfx::Pmfx::create(&mut device, 0);
     pmfx.load(&hotline_rs::get_data_path("shaders/raytracing_example"))?;
-
-    // TODO: reconfigure pmfx data
    
-    // TODO: hit group parms from PMFX? +1
-    // .. can have multiple shaders of each type
-    // .. import multiple shader stages per hit group (ch, ah, is)
-    // .. export multiple hit groups
-
-    /* ie: 
-    {
-        "hitGroups": [
-            {
-                "name": "SimpleHitGroup",
-                "shaders": {
-                    "closestHit": "ClosestHitShader"
-                }
-                },
-                {
-                "name": "TransparentHitGroup",
-                "shaders": {
-                    "closestHit": "ClosestHitShader",
-                    "anyHit": "AnyHitShader"
-                }
-                },
-                {
-                "name": "ProceduralHitGroup",
-                "shaders": {
-                    "closestHit": "ClosestHitShader",
-                    "intersection": "IntersectionShader"
-                }
-            }
-        ]
-        }
-    */
-   
-    pmfx.create_raytracing_pipeline(&device, "raytracing");
+    pmfx.create_raytracing_pipeline(&device, "raytracing")?;
 
     // TODO: create ray tracing acceleration structures +0
     // TODO: shader tables +2

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -1,4 +1,8 @@
+use gfx::AccelerationStructureBuildFlags;
 use gfx::BufferUsage;
+use gfx::RaytracingBLASInfo;
+use gfx::RaytracingInstanceInfo;
+use gfx::RaytracingTLASInfo;
 use hotline_rs::*;
 
 use gfx::CmdBuf;
@@ -80,20 +84,32 @@ fn main() -> Result<(), hotline_rs::Error> {
         initial_state: gfx::ResourceState::GenericRead
     }, Some(&vertices))?;
 
-    device.create_raytracing_blas(&gfx::RaytracingGeometryInfo::Triangles(
-        gfx::RaytracingTrianglesInfo {
-            index_buffer: &index_buffer,
-            vertex_buffer: &vertex_buffer,
-            transform3x4: None,
-            index_count: 3,
-            index_format: gfx::Format::R16u,
-            vertex_count: 3,
-            vertex_format: gfx::Format::RGB32f,
-            flags: gfx::RaytracingGeometryFlags::OPAQUE
-        }
-    ))?;
+    let blas = device.create_raytracing_blas(&RaytracingBLASInfo {
+        geometry: gfx::RaytracingGeometryInfo::Triangles(
+            gfx::RaytracingTrianglesInfo {
+                index_buffer: &index_buffer,
+                vertex_buffer: &vertex_buffer,
+                transform3x4: None,
+                index_count: 3,
+                index_format: gfx::Format::R16u,
+                vertex_count: 3,
+                vertex_format: gfx::Format::RGB32f,
+            }),
+        geometry_flags: gfx::RaytracingGeometryFlags::OPAQUE,
+        build_flags: AccelerationStructureBuildFlags::PREFER_FAST_TRACE
+    })?;
 
-    // TODO: create tlas
+    let _ = device.create_raytracing_tlas(&RaytracingTLASInfo {
+        instances: &vec![RaytracingInstanceInfo {
+            transform: [0.0; 12],
+            instance_id: 0,
+            instance_mask: 0,
+            hit_group_index: 0,
+            instance_flags: 0,
+            blas: &blas
+        }],
+        build_flags: AccelerationStructureBuildFlags::PREFER_FAST_TRACE
+    })?;
 
     // TODO: dispatch rays
 

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -74,12 +74,10 @@ fn main() -> Result<(), hotline_rs::Error> {
         initial_state: gfx::ResourceState::GenericRead
     }, Some(&vec![0 as u16, 1 as u16, 2 as u16]))?;
 
-    let offset = 0.75;
-    let depth = 1.0;
     let vertices: Vec<f32> = vec![
-        0.0, -offset, depth,
-        -offset, offset, depth,
-        offset, offset, depth
+        0.0, -0.25, 1.0,
+        -0.25, 0.25, 1.0,
+        0.25, 0.25, 1.0
     ];
     
     let vertex_buffer = device.create_buffer(&gfx::BufferInfo {

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), hotline_rs::Error> {
     pmfx.create_raytracing_pipeline(&device, "raytracing")?;
 
     let index_buffer = device.create_buffer(&gfx::BufferInfo {
-        usage: BufferUsage::ACCELERATION_STRUCTURE,
+        usage: BufferUsage::UPLOAD,
         cpu_access: gfx::CpuAccessFlags::WRITE,
         format: gfx::Format::R16u,
         stride: 2,
@@ -72,7 +72,7 @@ fn main() -> Result<(), hotline_rs::Error> {
     ];
     
     let vertex_buffer = device.create_buffer(&gfx::BufferInfo {
-        usage: BufferUsage::ACCELERATION_STRUCTURE,
+        usage: BufferUsage::UPLOAD,
         cpu_access: gfx::CpuAccessFlags::WRITE,
         format: gfx::Format::RGB32f,
         stride: 12,
@@ -92,6 +92,8 @@ fn main() -> Result<(), hotline_rs::Error> {
             flags: gfx::RaytracingGeometryFlags::OPAQUE
         }
     ))?;
+
+    // TODO: create tlas
 
     // TODO: dispatch rays
 

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -56,13 +56,18 @@ fn main() -> Result<(), hotline_rs::Error> {
     let mut swap_chain = device.create_swap_chain::<os_platform::App>(&swap_chain_info, &window)?;
     let mut cmd = device.create_cmd_buf(num_buffers);
 
+
+    let mut pmfx : pmfx::Pmfx<gfx_platform::Device> = pmfx::Pmfx::create(&mut device, 0);
+    pmfx.load(&hotline_rs::get_data_path("shaders/raytracing_example"))?;
+    pmfx.create_raytracing_pipeline(&device, "raytracing");
+
+    /*
     // create raytracing shaders
     let raygen_shader = device.create_shader(&gfx::ShaderInfo {
         shader_type: gfx::ShaderType::RayGen,
         compile_info: None
     }, &fs::read(hotline_rs::get_data_path("shaders/raygen.cso"))?)?;
 
-    /*
     let closest_hit_shader = device.create_shader(&gfx::ShaderInfo {
         shader_type: gfx::ShaderType::ClosestHit,
         compile_info: None
@@ -72,7 +77,6 @@ fn main() -> Result<(), hotline_rs::Error> {
         shader_type: gfx::ShaderType::Miss,
         compile_info: None
     }, &fs::read(hotline_rs::get_data_path("shaders/miss.cso"))?)?;
-    */
 
     // create raytracing pipeline
     let raytracing_pipeline = device.create_raytracing_pipeline(&RaytracingPipelineInfo{
@@ -80,6 +84,7 @@ fn main() -> Result<(), hotline_rs::Error> {
         closest_hit_shader: None, //Some((&closest_hit_shader, "MyClosestHitShader")),
         miss_shader: None, // Some((&miss_shader, "MyMissShader")),
     });
+    */
     
     while app.run() {
         // update window and swap chain

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -58,7 +58,46 @@ fn main() -> Result<(), hotline_rs::Error> {
 
     let mut pmfx : pmfx::Pmfx<gfx_platform::Device> = pmfx::Pmfx::create(&mut device, 0);
     pmfx.load(&hotline_rs::get_data_path("shaders/raytracing_example"))?;
+
+    // TODO: reconfigure pmfx data
+   
+    // TODO: hit group parms from PMFX? +1
+    // .. can have multiple shaders of each type
+    // .. import multiple shader stages per hit group (ch, ah, is)
+    // .. export multiple hit groups
+
+    /* ie: 
+    {
+        "hitGroups": [
+            {
+                "name": "SimpleHitGroup",
+                "shaders": {
+                    "closestHit": "ClosestHitShader"
+                }
+                },
+                {
+                "name": "TransparentHitGroup",
+                "shaders": {
+                    "closestHit": "ClosestHitShader",
+                    "anyHit": "AnyHitShader"
+                }
+                },
+                {
+                "name": "ProceduralHitGroup",
+                "shaders": {
+                    "closestHit": "ClosestHitShader",
+                    "intersection": "IntersectionShader"
+                }
+            }
+        ]
+        }
+    */
+   
     pmfx.create_raytracing_pipeline(&device, "raytracing");
+
+    // TODO: create ray tracing acceleration structures +0
+    // TODO: shader tables +2
+    // TODO: dispatch rays
 
     while app.run() {
         // update window and swap chain

--- a/examples/raytraced_triangle/main.rs
+++ b/examples/raytraced_triangle/main.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), hotline_rs::Error> {
     let offset = 0.75;
     let depth = 1.0;
     let vertices: Vec<f32> = vec![
-        0.0, offset, depth,
+        0.0, -offset, depth,
         -offset, offset, depth,
         offset, offset, depth
     ];
@@ -108,9 +108,13 @@ fn main() -> Result<(), hotline_rs::Error> {
 
     let tlas = device.create_raytracing_tlas(&RaytracingTLASInfo {
         instances: &vec![RaytracingInstanceInfo {
-            transform: [0.0; 12],
+            transform: [
+                1.0, 0.0, 0.0, 0.0, 
+                0.0, 1.0, 0.0, 0.0, 
+                0.0, 0.0, 1.0, 0.0
+            ],
             instance_id: 0,
-            instance_mask: 0,
+            instance_mask: 0xff,
             hit_group_index: 0,
             instance_flags: 0,
             blas: &blas

--- a/readme.md
+++ b/readme.md
@@ -801,6 +801,12 @@ Test for implementing and verifying the imgui backend - this demonstrates the en
 
 A standalone example of video playback, it allows you to load a video file from disk so it can be used to test compatibility of different video formats. The current implementation uses windows media foundation and Direct3D12 device to perform video decoding. The `av` API provides access to decoded video frames as a native `gfx::Texture` and performs all decoding on the GPU.
 
+### Raytraced Triangle
+
+A basic example to setup raytracing pipeline, it creates a BLAS consisting of a triangle mesh, TLAS with a single instance of the BLAS
+
+<img src="https://raw.githubusercontent.com/polymonster/polymonster.github.io/master/images/hotline/examples/raytraced_triangle.png" width="100%"/>
+
 ### Resource Tests
 
 This provides a testbed for loading different resource types, it loads some compressed texture formats and displays them to the screen to verify the texture build pipeline and the texture loading pipeline. It also tests the `copy_texture_region` API by copying a texture file specified in a `pmfx` into an empty texture also declared inside the `pmfx` config. This sample can be used in future as more resources are added.

--- a/shaders/raytracing_example.hlsl
+++ b/shaders/raytracing_example.hlsl
@@ -73,7 +73,7 @@ void raygen_shader()
     else
     {
         // Render interpolated DispatchRaysIndex outside the stencil window
-        output_target[DispatchRaysIndex().xy] = float4(lerp_values, 0.0, 1.0);
+        output_target[DispatchRaysIndex().xy] = float4(lerp_values, 1.0, 1.0);
     }
 }
 

--- a/shaders/raytracing_example.hlsl
+++ b/shaders/raytracing_example.hlsl
@@ -1,5 +1,4 @@
-#ifndef RAYTRACING_HLSL
-#define RAYTRACING_HLSL
+// This is ported from the Direct3D12 samples: https://github.com/microsoft/directx-graphics-samples/tree/master/Samples/Desktop/D3D12Raytracing
 
 struct Viewport
 {
@@ -14,70 +13,69 @@ struct RayGenConstantBuffer
     Viewport viewport;
     Viewport stencil;
 };
-RaytracingAccelerationStructure Scene : register(t0, space0);
-RWTexture2D<float4> RenderTarget : register(u0);
-ConstantBuffer<RayGenConstantBuffer> g_rayGenCB : register(b0);
 
-typedef BuiltInTriangleIntersectionAttributes MyAttributes;
 struct RayPayload
 {
     float4 color;
 };
 
-bool IsInsideViewport(float2 p, Viewport viewport)
+RaytracingAccelerationStructure         scene               : register(t0, space0);
+RWTexture2D<float4>                     output_target       : register(u0);
+ConstantBuffer<RayGenConstantBuffer>    raygen_constants    : register(b0);
+
+bool inside_viewport(float2 p, Viewport viewport)
 {
     return (p.x >= viewport.left && p.x <= viewport.right)
         && (p.y >= viewport.top && p.y <= viewport.bottom);
 }
 
 [shader("raygeneration")]
-void MyRaygenShader()
+void raygen_shader()
 {
-    float2 lerpValues = (float2)DispatchRaysIndex() / (float2)DispatchRaysDimensions();
+    float2 lerp_values = (float2)DispatchRaysIndex() / (float2)DispatchRaysDimensions();
 
     // Orthographic projection since we're raytracing in screen space.
-    float3 rayDir = float3(0, 0, 1);
+    float3 ray_dir = float3(0, 0, 1);
     float3 origin = float3(
-        lerp(g_rayGenCB.viewport.left, g_rayGenCB.viewport.right, lerpValues.x),
-        lerp(g_rayGenCB.viewport.top, g_rayGenCB.viewport.bottom, lerpValues.y),
+        lerp(raygen_constants.viewport.left, raygen_constants.viewport.right, lerp_values.x),
+        lerp(raygen_constants.viewport.top, raygen_constants.viewport.bottom, lerp_values.y),
         0.0f);
 
 
-    if (IsInsideViewport(origin.xy, g_rayGenCB.stencil))
+    if (inside_viewport(origin.xy, raygen_constants.stencil))
     {
         // Trace the ray.
         // Set the ray's extents.
         RayDesc ray;
         ray.Origin = origin;
-        ray.Direction = rayDir;
+        ray.Direction = ray_dir;
+        
         // Set TMin to a non-zero small value to avoid aliasing issues due to floating - point errors.
         // TMin should be kept small to prevent missing geometry at close contact areas.
         ray.TMin = 0.001;
         ray.TMax = 10000.0;
-        RayPayload payload = { float4(0, 0, 0, 0) };
-        TraceRay(Scene, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, ~0, 0, 1, 0, ray, payload);
+        RayPayload payload = { float4(0, 0, 1, 0) };
+        TraceRay(scene, RAY_FLAG_NONE, ~0, 0, 1, 0, ray, payload);
 
         // Write the raytraced color to the output texture.
-        RenderTarget[DispatchRaysIndex().xy] = payload.color;
+        output_target[DispatchRaysIndex().xy] = payload.color;
     }
     else
     {
         // Render interpolated DispatchRaysIndex outside the stencil window
-        RenderTarget[DispatchRaysIndex().xy] = float4(lerpValues, 0, 1);
+        output_target[DispatchRaysIndex().xy] = float4(lerp_values, 0, 1);
     }
 }
 
 [shader("closesthit")]
-void MyClosestHitShader(inout RayPayload payload, in MyAttributes attr)
+void closest_hit_shader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     float3 barycentrics = float3(1 - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x, attr.barycentrics.y);
     payload.color = float4(barycentrics, 1);
 }
 
 [shader("miss")]
-void MyMissShader(inout RayPayload payload)
+void miss_shader(inout RayPayload payload)
 {
-    payload.color = float4(0, 0, 0, 1);
+    payload.color = float4(1, 0, 0, 1);
 }
-
-#endif // RAYTRACING_HLSL

--- a/shaders/raytracing_example.hlsl
+++ b/shaders/raytracing_example.hlsl
@@ -1,0 +1,82 @@
+#ifndef RAYTRACING_HLSL
+#define RAYTRACING_HLSL
+
+struct Viewport
+{
+    float left;
+    float top;
+    float right;
+    float bottom;
+};
+
+struct RayGenConstantBuffer
+{
+    Viewport viewport;
+    Viewport stencil;
+};
+RaytracingAccelerationStructure Scene : register(t0, space0);
+RWTexture2D<float4> RenderTarget : register(u0);
+ConstantBuffer<RayGenConstantBuffer> g_rayGenCB : register(b0);
+
+typedef BuiltInTriangleIntersectionAttributes MyAttributes;
+struct RayPayload
+{
+    float4 color;
+};
+
+bool IsInsideViewport(float2 p, Viewport viewport)
+{
+    return (p.x >= viewport.left && p.x <= viewport.right)
+        && (p.y >= viewport.top && p.y <= viewport.bottom);
+}
+
+[shader("raygeneration")]
+void MyRaygenShader()
+{
+    float2 lerpValues = (float2)DispatchRaysIndex() / (float2)DispatchRaysDimensions();
+
+    // Orthographic projection since we're raytracing in screen space.
+    float3 rayDir = float3(0, 0, 1);
+    float3 origin = float3(
+        lerp(g_rayGenCB.viewport.left, g_rayGenCB.viewport.right, lerpValues.x),
+        lerp(g_rayGenCB.viewport.top, g_rayGenCB.viewport.bottom, lerpValues.y),
+        0.0f);
+
+    if (IsInsideViewport(origin.xy, g_rayGenCB.stencil))
+    {
+        // Trace the ray.
+        // Set the ray's extents.
+        RayDesc ray;
+        ray.Origin = origin;
+        ray.Direction = rayDir;
+        // Set TMin to a non-zero small value to avoid aliasing issues due to floating - point errors.
+        // TMin should be kept small to prevent missing geometry at close contact areas.
+        ray.TMin = 0.001;
+        ray.TMax = 10000.0;
+        RayPayload payload = { float4(0, 0, 0, 0) };
+        TraceRay(Scene, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, ~0, 0, 1, 0, ray, payload);
+
+        // Write the raytraced color to the output texture.
+        RenderTarget[DispatchRaysIndex().xy] = payload.color;
+    }
+    else
+    {
+        // Render interpolated DispatchRaysIndex outside the stencil window
+        RenderTarget[DispatchRaysIndex().xy] = float4(lerpValues, 0, 1);
+    }
+}
+
+[shader("closesthit")]
+void MyClosestHitShader(inout RayPayload payload, in MyAttributes attr)
+{
+    float3 barycentrics = float3(1 - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x, attr.barycentrics.y);
+    payload.color = float4(barycentrics, 1);
+}
+
+[shader("miss")]
+void MyMissShader(inout RayPayload payload)
+{
+    payload.color = float4(0, 0, 0, 1);
+}
+
+#endif // RAYTRACING_HLSL

--- a/shaders/raytracing_example.hlsl
+++ b/shaders/raytracing_example.hlsl
@@ -1,4 +1,5 @@
-// This is ported from the Direct3D12 samples: https://github.com/microsoft/directx-graphics-samples/tree/master/Samples/Desktop/D3D12Raytracing
+// This is ported from the Direct3D12 samples, with some slight modifications: 
+// Original: https://github.com/microsoft/directx-graphics-samples/tree/master/Samples/Desktop/D3D12Raytracing
 
 struct Viewport
 {
@@ -35,11 +36,20 @@ void raygen_shader()
     float2 lerp_values = (float2)DispatchRaysIndex() / (float2)DispatchRaysDimensions();
 
     // Orthographic projection since we're raytracing in screen space.
-    float3 ray_dir = float3(0, 0, 1);
+    float3 ray_dir = float3(0.0, 0.0, 1.0);
     float3 origin = float3(
-        lerp(raygen_constants.viewport.left, raygen_constants.viewport.right, lerp_values.x),
-        lerp(raygen_constants.viewport.top, raygen_constants.viewport.bottom, lerp_values.y),
-        0.0f);
+        lerp(
+            raygen_constants.viewport.left, 
+            raygen_constants.viewport.right, 
+            lerp_values.x
+        ),
+        lerp(
+            raygen_constants.viewport.top, 
+            raygen_constants.viewport.bottom, 
+            lerp_values.y
+        ),
+        0.0f
+    );
 
 
     if (inside_viewport(origin.xy, raygen_constants.stencil))
@@ -54,8 +64,8 @@ void raygen_shader()
         // TMin should be kept small to prevent missing geometry at close contact areas.
         ray.TMin = 0.001;
         ray.TMax = 10000.0;
-        RayPayload payload = { float4(0, 0, 1, 0) };
-        TraceRay(scene, RAY_FLAG_NONE, ~0, 0, 1, 0, ray, payload);
+        RayPayload payload = { float4(0.0, 0.0, 1.0, 0.0) };
+        TraceRay(scene, RAY_FLAG_NONE, ~0, 0.0, 1.0, 0.0, ray, payload);
 
         // Write the raytraced color to the output texture.
         output_target[DispatchRaysIndex().xy] = payload.color;
@@ -63,7 +73,7 @@ void raygen_shader()
     else
     {
         // Render interpolated DispatchRaysIndex outside the stencil window
-        output_target[DispatchRaysIndex().xy] = float4(lerp_values, 0, 1);
+        output_target[DispatchRaysIndex().xy] = float4(lerp_values, 0.0, 1.0);
     }
 }
 
@@ -71,11 +81,11 @@ void raygen_shader()
 void closest_hit_shader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     float3 barycentrics = float3(1 - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x, attr.barycentrics.y);
-    payload.color = float4(barycentrics, 1);
+    payload.color = float4(float3(1.0, 1.0, 1.0) - barycentrics, 1.0);
 }
 
 [shader("miss")]
 void miss_shader(inout RayPayload payload)
 {
-    payload.color = float4(1, 0, 0, 1);
+    payload.color = float4(0.5, 0.5, 0.5, 1.0);
 }

--- a/shaders/raytracing_example.hlsl
+++ b/shaders/raytracing_example.hlsl
@@ -42,6 +42,7 @@ void MyRaygenShader()
         lerp(g_rayGenCB.viewport.top, g_rayGenCB.viewport.bottom, lerpValues.y),
         0.0f);
 
+
     if (IsInsideViewport(origin.xy, g_rayGenCB.stencil))
     {
         // Trace the ray.

--- a/shaders/raytracing_example.pmfx
+++ b/shaders/raytracing_example.pmfx
@@ -13,6 +13,9 @@
                     geometry: Triangles
                 }
             ]
+            push_constants: [
+                "g_rayGenCB"
+            ]
         }
     }
 }

--- a/shaders/raytracing_example.pmfx
+++ b/shaders/raytracing_example.pmfx
@@ -5,16 +5,16 @@
 
     pipelines: {
         raytracing: {
-            lib: ["MyRaygenShader", "MyClosestHitShader", "MyMissShader"]
+            lib: ["raygen_shader", "closest_hit_shader", "miss_shader"]
             hit_groups: [
                 {
-                    name: "MyHitGroup"
-                    closest_hit: "MyClosestHitShader"
+                    name: "hit_group"
+                    closest_hit: "closest_hit_shader"
                     geometry: Triangles
                 }
             ]
             push_constants: [
-                "g_rayGenCB"
+                "raygen_constants"
             ]
         }
     }

--- a/shaders/raytracing_example.pmfx
+++ b/shaders/raytracing_example.pmfx
@@ -16,6 +16,11 @@
             push_constants: [
                 "raygen_constants"
             ]
+            sbt: {
+                ray_generation_shader: "raygen_shader",
+                miss_shaders: ["miss_shader"],
+                hit_groups: ["hit_group"],
+            }
         }
     }
 }

--- a/shaders/raytracing_example.pmfx
+++ b/shaders/raytracing_example.pmfx
@@ -5,9 +5,14 @@
 
     pipelines: {
         raytracing: {
-            rg: "MyRaygenShader"
-            ch: "MyClosestHitShader"
-            mi: "MyMissShader"
+            lib: ["MyRaygenShader", "MyClosestHitShader", "MyMissShader"]
+            hit_groups: [
+                {
+                    name: "MyHitGroup"
+                    closest_hit: "MyClosestHitShader"
+                    geometry: Triangles
+                }
+            ]
         }
     }
 }

--- a/shaders/raytracing_example.pmfx
+++ b/shaders/raytracing_example.pmfx
@@ -1,0 +1,13 @@
+{
+    include: [
+        "raytracing_example.hlsl"
+    ]
+
+    pipelines: {
+        raytracing: {
+            rg: "MyRaygenShader"
+            ch: "MyClosestHitShader"
+            mi: "MyMissShader"
+        }
+    }
+}

--- a/src/av/wmf.rs
+++ b/src/av/wmf.rs
@@ -155,7 +155,7 @@ impl super::VideoPlayer<d3d12::Device> for VideoPlayer {
 
             // make thread safe
             let mt : ID3D11Multithread = device.cast()?;
-            mt.SetMultithreadProtected(BOOL::from(true)).expect("hotline_rs::wmf::error: call to SetMultithreadProtected failed");
+            let _ = mt.SetMultithreadProtected(BOOL::from(true));
 
             // setup media engine
             let mut reset_token : u32 = 0;

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -789,6 +789,11 @@ pub struct RaytracingShaderBindingTableInfo<'stack, D: Device> {
     pub pipeline: &'stack D::RaytracingPipeline
 }
 
+// TODO: we must add flags
+//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_NONE: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(0i32);
+//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(2i32);
+//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(1i32);
+
 /// Information to create a raytracing bottom level acceleration structure from traingle geometry index and vertex buffers
 pub struct RaytracingTrianglesInfo<'stack, D: Device> {
     pub index_buffer: &'stack D::Buffer,
@@ -798,6 +803,17 @@ pub struct RaytracingTrianglesInfo<'stack, D: Device> {
     pub vertex_count: usize,
     pub index_format: Format,
     pub vertex_format: Format
+}
+
+/// Information to create a raytracing acceleration structure from aabbs
+pub struct RaytracingAABBsInfo<'stack, D: Device> {
+    pub aabbs: Option<&'stack D::Buffer>,
+    pub aabb_count: usize,
+}
+
+pub enum RaytracingGeometryInfo<'stack, D: Device> {
+    Triangles(RaytracingTrianglesInfo<'stack, D>),
+    AABBs(RaytracingAABBsInfo<'stack, D>)
 }
 
 /// Information to create a pipeline through `Device::create_texture`.
@@ -1119,6 +1135,8 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
     type RaytracingPipeline: RaytracingPipeline<Self>;
     type CommandSignature: CommandSignature<Self>;
     type RaytracingShaderBindingTable: RaytracingShaderBindingTable<Self>;
+    type RaytracingBLAS: RaytracingBLAS<Self>;
+    type RaytracingTLAS: RaytracingTLAS<Self>;
     /// Create a new GPU `Device` from `Device Info`
     fn create(info: &DeviceInfo) -> Self;
     /// Create a new resource `Heap` from `HeapInfo`
@@ -1190,9 +1208,11 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
         &self,
         info: &RaytracingShaderBindingTableInfo<Self>
     ) -> Result<Self::RaytracingShaderBindingTable, Error>;
+    /// Create a bottom level acceleration structure from `RaytracingGeometryInfo`
     fn create_raytracing_blas(
         &self,
-    );
+        info: RaytracingGeometryInfo<Self>
+    ) -> Result<Self::RaytracingBLAS, Error>;
     /// Create a command signature for `execute_indirect` commands associated on the `RenderPipeline`
     fn create_indirect_render_command<T: Sized>(
         &mut self, 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -379,6 +379,8 @@ bitflags! {
         const UPLOAD = (1 << 7);
         /// Only create the buffer and no views
         const BUFFER_ONLY = (1 << 8);
+        /// Used as acceleration
+        const ACCELERATION_STRUCTURE = (1 << 9);
     }
 
     /// Flags for raytracing geometry

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -375,8 +375,10 @@ bitflags! {
         const INDIRECT_ARGUMENT_BUFFER = (1 << 5);
         /// Used in shader as `AppendStructuredBuffer` and contains a counter element
         const APPEND_COUNTER = (1 << 6);
-        /// Acceleration structure
-        const ACCELERATION_STRUCTURE = (1 << 7);
+        /// Upload only buffer, can be used for acceleration structure geometry or to copy data
+        const UPLOAD = (1 << 7);
+        /// Only create the buffer and no views
+        const BUFFER_ONLY = (1 << 8);
     }
 
     pub struct RaytracingGeometryFlags : u8 {
@@ -936,6 +938,8 @@ pub enum ResourceState {
     GenericRead,
     /// Used for argument buffer in `execute_indirect` calls 
     IndirectArgument,
+    /// Used for destination acceleration structure buffers
+    AccelerationStructure
 }
 
 /// ome resources may contain subresources for resolving

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -834,7 +834,8 @@ pub struct RaytracingInstanceInfo<'stack, D: Device> {
     pub transform: [f32; 12],
     pub instance_id: u32,
     pub instance_mask: u32,
-    pub hit_group_mask: u32,
+    pub hit_group_index: u32,
+    pub instance_flags: u32,
     pub blas: &'stack D::RaytracingBLAS
 }
 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -375,6 +375,8 @@ bitflags! {
         const INDIRECT_ARGUMENT_BUFFER = (1 << 5);
         /// Used in shader as `AppendStructuredBuffer` and contains a counter element
         const APPEND_COUNTER = (1 << 6);
+        /// Acceleration structure
+        const ACCELERATION_STRUCTURE = (1 << 7);
     }
 
     pub struct RaytracingGeometryFlags : u8 {
@@ -1214,7 +1216,7 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
     /// Create a bottom level acceleration structure from `RaytracingGeometryInfo`
     fn create_raytracing_blas(
         &mut self,
-        info: RaytracingGeometryInfo<Self>
+        info: &RaytracingGeometryInfo<Self>
     ) -> Result<Self::RaytracingBLAS, Error>;
     /// Create a command signature for `execute_indirect` commands associated on the `RenderPipeline`
     fn create_indirect_render_command<T: Sized>(

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -747,22 +747,31 @@ pub struct ComputePipelineInfo<'stack, D: Device> {
 }
 
 pub struct RaytracingShader<'stack, D: Device> {
+    /// Reference to shader
     pub shader: &'stack D::Shader,
-    pub entry_point: String,
-    pub stage: ShaderType
+    /// Entry point name within shader
+    pub entry_point: String
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub enum RaytracingHitGeometry {
+    Triangles,
+    ProceduralPrimitive
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RaytracingHitGroup {
+    pub name: String,
+    pub any_hit: Option<String>,
+    pub closest_hit: Option<String>,
+    pub intersection: Option<String>,
+    pub geometry: RaytracingHitGeometry
 }
 
 /// Information to create a raytracing pipeline through `Device::create_raytracing_pipeline`
 pub struct RaytracingPipelineInfo<'stack, D: Device> {
-
-    //pub raygen_shader: Option<(&'stack D::Shader, String)>,
-    //pub any_hit_shader: Option<(&'stack D::Shader, String)>,
-    //pub closest_hit_shader: Option<(&'stack D::Shader, String)>,
-    //pub miss_shader: Option<(&'stack D::Shader, String)>,
-    //pub intersection_shader: Option<(&'stack D::Shader, String)>,
-    //pub callable_shader: Option<(&'stack D::Shader, String)>,
-
     pub shaders: Vec<RaytracingShader<'stack, D>>,
+    pub hit_groups: Option<Vec<RaytracingHitGroup>>,
     pub pipeline_layout: PipelineLayout,
 }
 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -746,15 +746,23 @@ pub struct ComputePipelineInfo<'stack, D: Device> {
     pub pipeline_layout: PipelineLayout,
 }
 
+pub struct RaytracingShader<'stack, D: Device> {
+    pub shader: &'stack D::Shader,
+    pub entry_point: String,
+    pub stage: ShaderType
+}
 
 /// Information to create a raytracing pipeline through `Device::create_raytracing_pipeline`
 pub struct RaytracingPipelineInfo<'stack, D: Device> {
-    pub raygen_shader: Option<(&'stack D::Shader, &'stack str)>,
-    pub any_hit_shader: Option<(&'stack D::Shader, &'stack str)>,
-    pub closest_hit_shader: Option<(&'stack D::Shader, &'stack str)>,
-    pub miss_shader: Option<(&'stack D::Shader, &'stack str)>,
-    pub intersection_shader: Option<(&'stack D::Shader, &'stack str)>,
-    pub callable_shader: Option<(&'stack D::Shader, &'stack str)>,
+
+    //pub raygen_shader: Option<(&'stack D::Shader, String)>,
+    //pub any_hit_shader: Option<(&'stack D::Shader, String)>,
+    //pub closest_hit_shader: Option<(&'stack D::Shader, String)>,
+    //pub miss_shader: Option<(&'stack D::Shader, String)>,
+    //pub intersection_shader: Option<(&'stack D::Shader, String)>,
+    //pub callable_shader: Option<(&'stack D::Shader, String)>,
+
+    pub shaders: Vec<RaytracingShader<'stack, D>>,
     pub pipeline_layout: PipelineLayout,
 }
 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -1383,6 +1383,8 @@ pub trait CmdBuf<D: Device>: Send + Sync + Clone {
     fn set_render_pipeline(&self, pipeline: &D::RenderPipeline);
     /// Set a compute pipeline for `dispatch`
     fn set_compute_pipeline(&self, pipeline: &D::ComputePipeline);
+    /// Set a raytracing pipeline for `dispatch_rays`
+    fn set_raytracing_pipeline(&self, pipeline: &D::RaytracingPipeline);
     /// Set's the active shader heap for the pipeline (srv, uav and cbv) and sets all descriptor tables to the root of the heap
     fn set_heap<T: Pipeline>(&self, pipeline: &T, heap: &D::Heap);
     /// Binds the heap with offset (texture srv, uav) on to the `slot` of a pipeline.

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -1308,8 +1308,8 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
 pub trait SwapChain<D: Device>: 'static + Sized + Any + Send + Sync + Clone {
     /// Call to begin a new frame, to synconise with v-sync and internally swap buffers
     fn new_frame(&mut self);
-    /// Update to syncornise with the window, this may require the backbuffer to resize
-    fn update<A: os::App>(&mut self, device: &mut D, window: &A::Window, cmd: &mut D::CmdBuf);
+    /// Update to syncornise with the window, this may require the backbuffer to resize, returns true if a resize occured
+    fn update<A: os::App>(&mut self, device: &mut D, window: &A::Window, cmd: &mut D::CmdBuf) -> bool;
     /// Waits on the CPU for the last frame that was submitted with `swap` to be completed by the GPU
     fn wait_for_last_frame(&self);
     /// Returns the fence value for the current frame, you can use this to syncronise reads

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -283,8 +283,11 @@ pub enum ShaderType {
     Fragment,
     Compute,
     RayGen,
+    AnyHit,
     ClosestHit,
-    Miss
+    Miss,
+    Intersection,
+    Callable
 }
 
 bitflags! {
@@ -747,8 +750,12 @@ pub struct ComputePipelineInfo<'stack, D: Device> {
 /// Information to create a raytracing pipeline through `Device::create_raytracing_pipeline`
 pub struct RaytracingPipelineInfo<'stack, D: Device> {
     pub raygen_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub any_hit_shader: Option<(&'stack D::Shader, &'stack str)>,
     pub closest_hit_shader: Option<(&'stack D::Shader, &'stack str)>,
     pub miss_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub intersection_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub callable_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub pipeline_layout: PipelineLayout,
 }
 
 /// Information to create a pipeline through `Device::create_texture`.

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -789,6 +789,17 @@ pub struct RaytracingShaderBindingTableInfo<'stack, D: Device> {
     pub pipeline: &'stack D::RaytracingPipeline
 }
 
+/// Information to create a raytracing bottom level acceleration structure from traingle geometry index and vertex buffers
+pub struct RaytracingTrianglesInfo<'stack, D: Device> {
+    pub index_buffer: &'stack D::Buffer,
+    pub vertex_buffer: &'stack D::Buffer,
+    pub transform3x4: Option<&'stack D::Buffer>,
+    pub index_count: usize,
+    pub vertex_count: usize,
+    pub index_format: Format,
+    pub vertex_format: Format
+}
+
 /// Information to create a pipeline through `Device::create_texture`.
 #[derive(Copy, Clone)]
 pub struct TextureInfo {
@@ -954,6 +965,7 @@ pub trait RenderPass<D: Device>: Send + Sync  {
     /// hash is based on render target format, depth stencil format and MSAA sample count
     fn get_format_hash(&self) -> u64;
 }
+
 /// An opaque compute pipeline type..
 pub trait ComputePipeline<D: Device>: Send + Sync  {}
 
@@ -962,6 +974,12 @@ pub trait RaytracingPipeline<D: Device>: Send + Sync  {}
 
 /// An opaque shader table binding type..
 pub trait RaytracingShaderBindingTable<D: Device>: Send + Sync  {}
+
+/// An opaque top level acceleration structure for ray tracing geometry
+pub trait RaytracingTLAS<D: Device>: Send + Sync  {}
+
+/// An opaque bottom level acceleration structure for ray tracing geometry
+pub trait RaytracingBLAS<D: Device>: Send + Sync  {}
 
 /// A pipeline trait for shared functionality between Compute and Render pipelines
 pub trait Pipeline {
@@ -1167,10 +1185,14 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
         &self,
         info: &RaytracingPipelineInfo<Self>,
     ) -> Result<Self::RaytracingPipeline, Error>;
-    fn create_ray_tracing_shader_binding_table(
+    /// Create a new raytracing shader binding table from `RaytracingShaderBindingTableInfo`
+    fn create_raytracing_shader_binding_table(
         &self,
         info: &RaytracingShaderBindingTableInfo<Self>
     ) -> Result<Self::RaytracingShaderBindingTable, Error>;
+    fn create_raytracing_blas(
+        &self,
+    );
     /// Create a command signature for `execute_indirect` commands associated on the `RenderPipeline`
     fn create_indirect_render_command<T: Sized>(
         &mut self, 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -282,6 +282,9 @@ pub enum ShaderType {
     Vertex,
     Fragment,
     Compute,
+    RayGen,
+    ClosestHit,
+    Miss
 }
 
 bitflags! {
@@ -740,6 +743,14 @@ pub struct ComputePipelineInfo<'stack, D: Device> {
     pub pipeline_layout: PipelineLayout,
 }
 
+
+/// Information to create a raytracing pipeline through `Device::create_raytracing_pipeline`
+pub struct RaytracingPipelineInfo<'stack, D: Device> {
+    pub raygen_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub closest_hit_shader: Option<(&'stack D::Shader, &'stack str)>,
+    pub miss_shader: Option<(&'stack D::Shader, &'stack str)>,
+}
+
 /// Information to create a pipeline through `Device::create_texture`.
 #[derive(Copy, Clone)]
 pub struct TextureInfo {
@@ -908,6 +919,9 @@ pub trait RenderPass<D: Device>: Send + Sync  {
 /// An opaque compute pipeline type..
 pub trait ComputePipeline<D: Device>: Send + Sync  {}
 
+/// An opaque compute pipeline type..
+pub trait RaytracingPipeline<D: Device>: Send + Sync  {}
+
 /// A pipeline trait for shared functionality between Compute and Render pipelines
 pub trait Pipeline {
     /// Returns the `PipelineSlotInfo` of which slot to bind a heap to based on the reequested `register` and `descriptor_type`
@@ -1043,6 +1057,7 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
     type Heap: Heap<Self>;
     type QueryHeap: QueryHeap<Self>;
     type ComputePipeline: ComputePipeline<Self>;
+    type RaytracingPipeline: RaytracingPipeline<Self>;
     type CommandSignature: CommandSignature<Self>;
     /// Create a new GPU `Device` from `Device Info`
     fn create(info: &DeviceInfo) -> Self;
@@ -1105,6 +1120,11 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
         &self,
         info: &ComputePipelineInfo<Self>,
     ) -> Result<Self::ComputePipeline, Error>;
+    /// Create a new raytracing pipeline state object from `RaytracingPipelineInfo`
+    fn create_raytracing_pipeline(
+        &self,
+        info: &RaytracingPipelineInfo<Self>,
+    ) -> Result<Self::RaytracingPipeline, Error>;
     /// Creat a command signature for `execute_indirect` commands associated on the `RenderPipeline`
     fn create_indirect_render_command<T: Sized>(
         &mut self, 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -775,6 +775,13 @@ pub struct RaytracingPipelineInfo<'stack, D: Device> {
     pub pipeline_layout: PipelineLayout,
 }
 
+pub struct RaytacingShaderBindingTable<D: Device> {
+    pub ray_generation: D::ShaderTable,
+    pub miss: D::ShaderTable,
+    pub hit_group: D::ShaderTable,
+    pub callable: D::ShaderTable
+}
+
 /// Information to create a pipeline through `Device::create_texture`.
 #[derive(Copy, Clone)]
 pub struct TextureInfo {
@@ -946,6 +953,9 @@ pub trait ComputePipeline<D: Device>: Send + Sync  {}
 /// An opaque compute pipeline type..
 pub trait RaytracingPipeline<D: Device>: Send + Sync  {}
 
+/// An opaque shader table type..
+pub trait ShaderTable<D: Device>: Send + Sync  {}
+
 /// A pipeline trait for shared functionality between Compute and Render pipelines
 pub trait Pipeline {
     /// Returns the `PipelineSlotInfo` of which slot to bind a heap to based on the reequested `register` and `descriptor_type`
@@ -1083,6 +1093,7 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
     type ComputePipeline: ComputePipeline<Self>;
     type RaytracingPipeline: RaytracingPipeline<Self>;
     type CommandSignature: CommandSignature<Self>;
+    type ShaderTable: ShaderTable<Self>;
     /// Create a new GPU `Device` from `Device Info`
     fn create(info: &DeviceInfo) -> Self;
     /// Create a new resource `Heap` from `HeapInfo`

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -1421,6 +1421,8 @@ pub trait CmdBuf<D: Device>: Send + Sync + Clone {
         counter_buffer: Option<&D::Buffer>,
         counter_buffer_offset: usize
     );
+    /// Issue dispatch call for ray tracing with the specified `RaytracingShaderBindingTable` which is associated with the bound `RaytracingPipeline`
+    fn dispatch_rays(&self, sbt: &D::RaytracingShaderBindingTable, numthreads: Size3);
     /// Resolves the `subresource` (mip index, 3d texture slice or array slice)
     fn resolve_texture_subresource(&self, texture: &D::Texture, subresource: u32) -> Result<(), Error>;
     /// Generates a full mip chain for the specified `texture` where `heap` is the shader heap the texture was created on 

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -1036,9 +1036,6 @@ pub trait RaytracingPipeline<D: Device>: Send + Sync  {}
 /// An opaque shader table binding type..
 pub trait RaytracingShaderBindingTable<D: Device>: Send + Sync  {}
 
-/// An opaque top level acceleration structure for ray tracing geometry
-pub trait RaytracingTLAS<D: Device>: Send + Sync  {}
-
 /// An opaque bottom level acceleration structure for ray tracing geometry
 pub trait RaytracingBLAS<D: Device>: Send + Sync  {}
 
@@ -1390,6 +1387,8 @@ pub trait CmdBuf<D: Device>: Send + Sync + Clone {
     /// Binds the heap with offset (texture srv, uav) on to the `slot` of a pipeline.
     /// this is like a traditional bindful render architecture `cmd.set_binding(pipeline, heap, 0, texture1_id)`
     fn set_binding<T: Pipeline>(&self, pipeline: &T, heap: &D::Heap, slot: u32, offset: usize);
+    // TODO:
+    fn set_tlas(&self, tlas: &D::RaytracingTLAS);
     /// Push a small amount of data into the command buffer for a render pipeline, num values and dest offset are the numbr of 32bit values
     fn push_render_constants<T: Sized>(&self, slot: u32, num_values: u32, dest_offset: u32, data: &[T]);
     /// Push a small amount of data into the command buffer for a compute pipeline, num values and dest offset are the numbr of 32bit values
@@ -1498,6 +1497,14 @@ pub trait Texture<D: Device>: Send + Sync {
     fn is_resolvable(&self) -> bool;
     /// Return the id of the shader heap
     fn get_shader_heap_id(&self) -> Option<u16>;
+}
+
+/// An opaque top level acceleration structure for ray tracing geometry
+pub trait RaytracingTLAS<D: Device>: Send + Sync  {
+    /// Return the index to access in a shader (if the resource has msaa this is the resolved view)
+    fn get_srv_index(&self) -> Option<usize>;
+    /// Return the id of the shader heap
+    fn get_shader_heap_id(&self) -> u16;
 }
 
 /// An opaque shader heap type, use to create views of resources for binding and access in shaders

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -376,6 +376,12 @@ bitflags! {
         /// Used in shader as `AppendStructuredBuffer` and contains a counter element
         const APPEND_COUNTER = (1 << 6);
     }
+
+    pub struct RaytracingGeometryFlags : u8 {
+        const NONE = 0;
+        const NO_DUPLICATE_ANY_HIT = (1 << 0);
+        const OPAQUE = (1<<1);
+    }
 }
 
 /// `PipelineLayout` is required to create a pipeline it describes the layout of resources for access on the GPU.
@@ -789,11 +795,6 @@ pub struct RaytracingShaderBindingTableInfo<'stack, D: Device> {
     pub pipeline: &'stack D::RaytracingPipeline
 }
 
-// TODO: we must add flags
-//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_NONE: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(0i32);
-//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(2i32);
-//pub const D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE: D3D12_RAYTRACING_GEOMETRY_FLAGS = D3D12_RAYTRACING_GEOMETRY_FLAGS(1i32);
-
 /// Information to create a raytracing bottom level acceleration structure from traingle geometry index and vertex buffers
 pub struct RaytracingTrianglesInfo<'stack, D: Device> {
     pub index_buffer: &'stack D::Buffer,
@@ -802,13 +803,15 @@ pub struct RaytracingTrianglesInfo<'stack, D: Device> {
     pub index_count: usize,
     pub vertex_count: usize,
     pub index_format: Format,
-    pub vertex_format: Format
+    pub vertex_format: Format,
+    pub flags: RaytracingGeometryFlags
 }
 
 /// Information to create a raytracing acceleration structure from aabbs
 pub struct RaytracingAABBsInfo<'stack, D: Device> {
     pub aabbs: Option<&'stack D::Buffer>,
     pub aabb_count: usize,
+    pub flags: RaytracingGeometryFlags
 }
 
 pub enum RaytracingGeometryInfo<'stack, D: Device> {
@@ -1210,7 +1213,7 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
     ) -> Result<Self::RaytracingShaderBindingTable, Error>;
     /// Create a bottom level acceleration structure from `RaytracingGeometryInfo`
     fn create_raytracing_blas(
-        &self,
+        &mut self,
         info: RaytracingGeometryInfo<Self>
     ) -> Result<Self::RaytracingBLAS, Error>;
     /// Create a command signature for `execute_indirect` commands associated on the `RenderPipeline`

--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -812,7 +812,7 @@ pub struct RaytracingShaderBindingTableInfo<'stack, D: Device> {
     pub callable_shaders: Vec<String>,
     /// The names of the hit groups to use in the dispatch rays
     pub hit_groups: Vec<String>,
-    // The raytracing pipeline to bind shaders from within
+    /// The raytracing pipeline to bind shaders from within
     pub pipeline: &'stack D::RaytracingPipeline
 }
 

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -4280,6 +4280,10 @@ impl super::CmdBuf<Device> for CmdBuf {
         }
     }
 
+    fn dispatch_rays(&self, sbt: &RaytracingShaderBindingTable, numthreads: Size3) {
+        unimplemented!()
+    }
+
     fn read_back_backbuffer(&mut self, swap_chain: &SwapChain) -> result::Result<ReadBackRequest, super::Error> {
         let bb = self.bb_index;
         let bbz = self.bb_index as u32;

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -3114,7 +3114,7 @@ impl super::Device for Device {
         }
     }
 
-    fn create_ray_tracing_shader_binding_table(
+    fn create_raytracing_shader_binding_table(
         &self,
         info: &super::RaytracingShaderBindingTableInfo<Self>
     ) -> result::Result<RaytracingShaderBindingTable, super::Error> {
@@ -3198,6 +3198,38 @@ impl super::Device for Device {
                 callable: create_shader_table(hit_group_ids),
             })
         }
+    }
+
+    fn create_raytracing_blas(&self) {
+        // D3D12_RAYTRACING_GEOMETRY_DESC
+        // - from index / vertex upload buffer
+
+        // D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS
+        // D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO
+
+        // UAV ScratchResource based on geo scratch size
+        // UAV BLAS
+
+        // D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC
+
+        // BuildRaytracingAccelerationStructure
+        /*
+            auto BuildAccelerationStructure = [&](auto* raytracingCommandList)
+            {
+                raytracingCommandList->BuildRaytracingAccelerationStructure(&bottomLevelBuildDesc, 0, nullptr);
+                commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::UAV(m_bottomLevelAccelerationStructure.Get()));
+                raytracingCommandList->BuildRaytracingAccelerationStructure(&topLevelBuildDesc, 0, nullptr);
+            };
+
+            // Build acceleration structure.
+            BuildAccelerationStructure(m_dxrCommandList.Get());
+            
+            // Kick off acceleration structure construction.
+            m_deviceResources->ExecuteCommandList();
+
+            // Wait for GPU to finish as the locally created temporary GPU resources will get released once we go out of scope.
+            m_deviceResources->WaitForGpu();
+        */
     }
 
     fn create_indirect_render_command<T: Sized>(

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -2162,9 +2162,6 @@ impl super::Device for Device {
                     Flags: to_d3d12_buffer_usage_flags(info.usage),
                     ..Default::default()
                 },
-                D3D12_RESOURCE_STATE_COMMON,
-
-                /*
                 // initial state
                 if info.cpu_access.contains(super::CpuAccessFlags::WRITE) {
                     D3D12_RESOURCE_STATE_GENERIC_READ
@@ -2175,8 +2172,6 @@ impl super::Device for Device {
                 else {
                     to_d3d12_resource_state(info.initial_state)
                 },
-                */
-                
                 None,
                 &mut buf,
             )?;

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -2270,7 +2270,7 @@ impl super::Device for Device {
             let buf = buf.unwrap();
 
             // load buffer with initialised data
-            if let Some(data) = &data {
+            if data.is_some() {
                 let upload = upload.unwrap();
                 // copy resource from upload buffer
                 let fence: ID3D12Fence = self.device.CreateFence(0, D3D12_FENCE_FLAG_NONE).unwrap();
@@ -3329,8 +3329,6 @@ impl super::Device for Device {
             let cmd = self.command_list.cast::<ID3D12GraphicsCommandList4>().expect("hotline_rs::gfx::d3d12: expected ID3D12GraphicsCommandList4 availability to create raytracing blas");
             cmd.BuildRaytracingAccelerationStructure(&blas_desc, None);
 
-            // TODO: barrier?
-
             self.command_list.Close()?;
 
             // execute commandlist
@@ -3351,6 +3349,14 @@ impl super::Device for Device {
                 blas_buffer
             })
         }
+    }
+
+    fn create_raytracing_tlas(
+        &mut self,
+        _info: &Vec<RaytracingInstanceInfo<Self>>
+    ) -> result::Result<RaytracingTLAS, super::Error> {
+
+        unimplemented!()
     }
 
     fn create_indirect_render_command<T: Sized>(

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -3811,7 +3811,7 @@ impl super::SwapChain<Device> for SwapChain {
         self.frame_fence_value[self.bb_index]
     }
 
-    fn update<A: os::App>(&mut self, device: &mut Device, window: &A::Window, cmd: &mut CmdBuf) {
+    fn update<A: os::App>(&mut self, device: &mut Device, window: &A::Window, cmd: &mut CmdBuf) -> bool {
         let size = window.get_size();
         if (size.x != self.width || size.y != self.height) && size.x > 0 && size.y > 0 {
             unsafe {
@@ -3861,9 +3861,11 @@ impl super::SwapChain<Device> for SwapChain {
                 self.width = size.x;
                 self.height = size.y;
                 self.bb_index = 0;
+                true
             }
         } else {
             self.new_frame();
+            false
         }
     }
 

--- a/src/gfx/d3d12.rs
+++ b/src/gfx/d3d12.rs
@@ -1263,12 +1263,6 @@ impl Buffer {
             self.resource.as_ref().map(|x| x.GetGPUVirtualAddress()).unwrap_or(0)
         }
     }
-    /// Get the d3d virtual address as u64 or 0 if the resource is None
-    fn size_bytes(&self) -> u64 {
-        unsafe {
-            self.resource.as_ref().map(|x| x.GetDesc().Width).unwrap_or(0)
-        }
-    }
 }
 
 impl Device {
@@ -1709,8 +1703,8 @@ impl Shader {
 
 pub(crate) struct ShaderTable {
     pub buffer: Option<ID3D12Resource>,
-    pub count: usize,
-    pub stride: usize
+    pub _count: usize,
+    pub _stride: usize
 }
 
 pub struct RaytracingShaderBindingTable {
@@ -3250,8 +3244,8 @@ impl super::Device for Device {
                 if idents.is_empty() {
                     ShaderTable {
                         buffer: None,
-                        count: 0,
-                        stride: 0
+                        _count: 0,
+                        _stride: 0
                     }
                 }
                 else {
@@ -3296,8 +3290,8 @@ impl super::Device for Device {
 
                     ShaderTable {
                         buffer: table_buffer,
-                        count: idents.len(),
-                        stride: D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES as usize
+                        _count: idents.len(),
+                        _stride: D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES as usize
                     }
                 }
             };

--- a/src/imgui.rs
+++ b/src/imgui.rs
@@ -18,14 +18,9 @@ use std::ffi::CString;
 
 use maths_rs::Vec4f;
 
-use std::ptr::addr_of;
-use std::ptr::addr_of_mut;
-
-macro_rules! static_ref_mut{
-    ($place:expr) => {
-        &mut *addr_of_mut!($place)
-    }
-}
+use crate::static_ref;
+use crate::static_ref_mut;
+use crate::static_ref_array_mut;
 
 fn to_im_vec4(v: Vec4f) -> ImVec4 {
     unsafe {
@@ -641,7 +636,7 @@ impl<D, A> ImGui<D, A> where D: Device, A: App, D::RenderPipeline: gfx::Pipeline
                 let ini_file = parent.join("imgui.ini");
                 static mut NULL_INI_FILE : Option<CString> = None;
                 NULL_INI_FILE = Some(CString::new(ini_file.to_str().unwrap().to_string()).unwrap());
-                if let Some(i) = &*addr_of!(NULL_INI_FILE) {
+                if let Some(i) = static_ref!(NULL_INI_FILE) {
                     io.IniFilename = i.as_ptr() as _;
                 }
             };
@@ -1158,7 +1153,7 @@ impl<D, A> ImGui<D, A> where D: Device, A: App, D::RenderPipeline: gfx::Pipeline
                     "This is some useful text.\0".as_ptr() as *const i8,
                 );
 
-                igColorEdit3("clear color\0".as_ptr() as _, CLEAR_COLOUR.as_mut_ptr(), 0); // Edit 3 floats representing a color
+                igColorEdit3("color\0".as_ptr() as _, static_ref_array_mut!(CLEAR_COLOUR), 0); // Edit 3 floats representing a color
 
                 igText(
                     "Application average %.3f ms/frame (%.1f FPS)\0".as_ptr() as _,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,35 @@ fn get_files_recursive(dir: &str, mut files: Vec<String>) -> Vec<String> {
     files
 }
 
+// macros for static addr of convenience
+#[macro_export]
+macro_rules! static_ref{
+    ($place:expr) => {
+        &*std::ptr::addr_of!($place)
+    }
+}
+
+#[macro_export]
+macro_rules! static_ref_mut{
+    ($place:expr) => {
+        &mut *std::ptr::addr_of_mut!($place)
+    }
+}
+
+#[macro_export]
+macro_rules! static_ref_array{
+    ($place:expr) => {
+        &*std::ptr::addr_of!($place[0])
+    }
+}
+
+#[macro_export]
+macro_rules! static_ref_array_mut{
+    ($place:expr) => {
+        &mut *std::ptr::addr_of_mut!($place[0])
+    }
+}
+
 /// This is a hardcoded compile time selection of os backend for windows as win32
 #[cfg(target_os = "windows")]
 pub use os::win32 as os_platform;
@@ -152,7 +181,6 @@ pub use gfx::d3d12 as gfx_platform;
 /// This is a hardcoded compile time selection of os backend for windows as wmf
 #[cfg(target_os = "windows")]
 pub use av::wmf as av_platform;
-
 
 /// Most commonly used re-exported types.
 #[cfg(target_os = "windows")]

--- a/src/os/win32.rs
+++ b/src/os/win32.rs
@@ -238,6 +238,10 @@ pub fn string_to_wide(string: String) -> Vec<u16> {
     }
 }
 
+pub fn string_ref_to_wide(string: &String) -> Vec<u16> {
+    string_to_wide(string.clone())
+}
+
 pub fn wide_to_string(wide: PWSTR) -> String {
     let mut v : Vec<u16> = Vec::new();
     let mut counter = 0;

--- a/src/os/win32.rs
+++ b/src/os/win32.rs
@@ -226,7 +226,7 @@ pub fn string_to_wide(string: String) -> Vec<u16> {
             windows::Win32::Globalization::MULTI_BYTE_TO_WIDE_CHAR_FLAGS(0),
             null_string.as_bytes(),
             Some(vx.as_mut_slice()),
-        );
+        ) + 1;
         let mut v: Vec<u16> = vec![0; n as usize];
         MultiByteToWideChar(
             windows::Win32::Globalization::CP_UTF8,

--- a/src/os/win32.rs
+++ b/src/os/win32.rs
@@ -20,7 +20,8 @@ use std::result;
 use std::collections::HashMap;
 use std::ffi::CString;
 
-use std::ptr::addr_of;
+use crate::static_ref;
+use crate::static_ref_mut;
 
 #[derive(Clone)]
 pub struct App {
@@ -727,10 +728,10 @@ impl super::App for App {
 
     fn enumerate_display_monitors() -> Vec<super::MonitorInfo> {
         unsafe {
-            MONITOR_ENUM.clear();
+            static_ref_mut!(MONITOR_ENUM).clear();
             let _ = EnumDisplayMonitors(HDC::default(), None, Some(enum_func), LPARAM(0));
             let mut monitors: Vec<super::MonitorInfo> = Vec::new();
-            for m in &*addr_of!(MONITOR_ENUM) {
+            for m in static_ref!(MONITOR_ENUM) {
                 monitors.push(m.clone());
             }
             monitors
@@ -1244,7 +1245,7 @@ extern "system" fn enum_func(
                 1.0
             };
 
-        MONITOR_ENUM.push(super::MonitorInfo {
+        static_ref_mut!(MONITOR_ENUM).push(super::MonitorInfo {
             rect: super::Rect {
                 x: info.rcMonitor.left,
                 y: info.rcMonitor.top,

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -2130,10 +2130,10 @@ impl<D> Pmfx<D> where D: gfx::Device {
 
                 // TODO: this info should come from .pmfx data
                 let sbt = device.create_raytracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
-                    ray_generation_shader: String::from("MyRaygenShader"),
-                    miss_shaders: vec![String::from("MyMissShader")],
+                    ray_generation_shader: String::from("raygen_shader"),
+                    miss_shaders: vec![String::from("miss_shader")],
                     callable_shaders: Vec::new(),
-                    hit_groups: vec![String::from("MyHitGroup")],
+                    hit_groups: vec![String::from("hit_group")],
                     pipeline: &raytracing_pipeline
                 })?;
 

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -4,6 +4,7 @@ use crate::gfx::Buffer;
 use crate::gfx::PipelineStatistics;
 use crate::gfx::RaytracingPipelineInfo;
 
+use crate::gfx::RaytracingShaderBindingTableInfo;
 use crate::os;
 use crate::gfx;
 use crate::primitives;
@@ -2117,6 +2118,14 @@ impl<D> Pmfx<D> where D: gfx::Device {
                     shaders,
                     pipeline_layout: pipeline.pipeline_layout.clone(),
                     hit_groups: pipeline.hit_groups
+                })?;
+
+                let sbt = device.create_ray_tracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
+                    ray_generation_shader: String::from("MyRaygenShader"),
+                    miss_shaders: vec![String::from("MyMissShader")],
+                    callable_shaders: Vec::new(),
+                    hit_groups: vec![String::from("MyHitGroup")],
+                    pipeline: &raytracing_pipeline
                 })?;
             }
 

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -2120,7 +2120,8 @@ impl<D> Pmfx<D> where D: gfx::Device {
                     hit_groups: pipeline.hit_groups
                 })?;
 
-                let sbt = device.create_raytracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
+                // TODO: raytracing
+                let _sbt = device.create_raytracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
                     ray_generation_shader: String::from("MyRaygenShader"),
                     miss_shaders: vec![String::from("MyMissShader")],
                     callable_shaders: Vec::new(),

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -2117,7 +2117,7 @@ impl<D> Pmfx<D> where D: gfx::Device {
                     shaders,
                     pipeline_layout: pipeline.pipeline_layout.clone(),
                     hit_groups: pipeline.hit_groups
-                });
+                })?;
             }
 
             Ok(())

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -358,7 +358,7 @@ struct Pipeline {
     cs: Option<String>,
     lib: Option<Vec<String>>,
     hit_groups: Option<Vec<gfx::RaytracingHitGroup>>,
-    sbt: RaytracingShaderBindingTableInfo,
+    sbt: Option<RaytracingShaderBindingTableInfo>,
     numthreads: Option<(u32, u32, u32)>,
     vertex_layout: Option<gfx::InputLayout>,
     pipeline_layout: gfx::PipelineLayout,
@@ -2140,11 +2140,12 @@ impl<D> Pmfx<D> where D: gfx::Device {
                     hit_groups: pipeline.hit_groups
                 })?;
 
+                let sbt_info = pipeline.sbt.expect("hotline_rs::pmfx:: ray tracing pipeline expects a shader binding table (sbt) to be defined in pmfx");
                 let sbt = device.create_raytracing_shader_binding_table(&gfx::RaytracingShaderBindingTableInfo{
-                    ray_generation_shader: pipeline.sbt.ray_generation_shader,
-                    miss_shaders: pipeline.sbt.miss_shaders,
-                    callable_shaders: pipeline.sbt.callable_shaders,
-                    hit_groups: pipeline.sbt.hit_groups,
+                    ray_generation_shader: sbt_info.ray_generation_shader,
+                    miss_shaders: sbt_info.miss_shaders,
+                    callable_shaders: sbt_info.callable_shaders,
+                    hit_groups: sbt_info.hit_groups,
                     pipeline: &raytracing_pipeline
                 })?;
 

--- a/src/pmfx.rs
+++ b/src/pmfx.rs
@@ -2120,7 +2120,7 @@ impl<D> Pmfx<D> where D: gfx::Device {
                     hit_groups: pipeline.hit_groups
                 })?;
 
-                let sbt = device.create_ray_tracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
+                let sbt = device.create_raytracing_shader_binding_table(&RaytracingShaderBindingTableInfo{
                     ray_generation_shader: String::from("MyRaygenShader"),
                     miss_shaders: vec![String::from("MyMissShader")],
                     callable_shaders: Vec::new(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -643,17 +643,6 @@ fn test_missing_camera() -> Result<(), hotline_rs::Error> {
     boot_client_ecs_plugin_demo("test_missing_camera")
 }
 
-/*
-#[test]
-fn draw() -> Result<(), hotline_rs::Error> {
-    for i in 0..100 {
-        boot_client_ecs_plugin_demo(format!("draw{i}").as_str());
-    }
-    Ok(())
-}
-    */
-
-
 //
 // ecs examples
 //


### PR DESCRIPTION
This PR adds raytracing support to the hotline `gfx` API and higher level support through the `pmfx` API.

There is a basic example (raytraced_triangle) to demonstrate the setup. It adds the following ray tracing structures:

- RaytracingPipeline
- RaytracingShaderBindingTable
- RaytracingBLAS
- RaytracingTLAS

