### PR TITLE
fix: correct occured and syncornise typos in gfx.rs

### DIFF
--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -1566,7 +1566,7 @@ pub trait Device: 'static + Send + Sync + Sized + Any + Clone {
 pub trait SwapChain<D: Device>: 'static + Sized + Any + Send + Sync + Clone {
     /// Call to begin a new frame, to synconise with v-sync and internally swap buffers
     fn new_frame(&mut self);
-    /// Update to syncornise with the window, this may require the backbuffer to resize, returns true if a resize occured
+    /// Update to synchronise with the window, this may require the backbuffer to resize, returns true if a resize occurred
     fn update<A: os::App>(&mut self, device: &mut D, window: &A::Window, cmd: &mut D::CmdBuf) -> bool;
     /// Waits on the CPU for the last frame that was submitted with `swap` to be completed by the GPU
     fn wait_for_last_frame(&self);


### PR DESCRIPTION
Fixes typos in gfx.rs:
- occured -> occurred
- syncornise -> synchronise